### PR TITLE
Change MariaDB port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./data/mariadb:/var/lib/mysql
     ports:
-      - 3306:3306
+      - 13306:3306
     command: |
       --character-set-server=utf8mb4
       --collation-server=utf8mb4_unicode_ci


### PR DESCRIPTION
Change port numbers to avoid port conflicts.

Keep your `3306` port!

Issue: https://www.facebook.com/tobyilee/posts/10216646684254101