### PR TITLE
프론트엔드 docker 배포 버그 해결?

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     environment:
       - VUE_APP_API_BASE_URL=http://localhost:8002
       - VUE_APP_LOGIN_API_BASE_URL=http://localhost:8001
-    command: bash -c "cd /home/eatgo && npm run serve"
+    command: bash -c "cd /home/eatgo && npm install && npm run serve"
     healthcheck:
       test: curl -sS http://localhost:8080 || exit 1
       timeout: 10s
@@ -81,7 +81,7 @@ services:
     environment:
       - VUE_APP_API_BASE_URL=http://localhost:8003
       - VUE_APP_LOGIN_API_BASE_URL=http://localhost:8001
-    command: bash -c "cd /home/eatgo && npm run serve"
+    command: bash -c "cd /home/eatgo && npm install && npm run serve"
     healthcheck:
       test: curl -sS http://localhost:8080 || exit 1
       timeout: 10s
@@ -95,7 +95,7 @@ services:
     environment:
       - VUE_APP_API_BASE_URL=http://localhost:8004
       - VUE_APP_LOGIN_API_BASE_URL=http://localhost:8001
-    command: bash -c "cd /home/eatgo && npm run serve"
+    command: bash -c "cd /home/eatgo && npm install && npm run serve"
     healthcheck:
       test: curl -sS http://localhost:8080 || exit 1
       timeout: 10s


### PR DESCRIPTION
- docker-compose 파일에서 프론트엔드 배포 명령어에 npm install을 추가했습니다.
- 이게 없으면 최초 실행 때 모듈이 없다면서 실행이 안됐습니다.
- 맞게 고친건지 확인 부탁드립니다!